### PR TITLE
remove some keywords in cargo config because crates.io accepts at mos…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 homepage = "https://github.com/SkwalExe/rust-logging"
 repository = "https://github.com/SkwalExe/rust-logging"
 license = "MIT"
-keywords = ["rust", "errors", "logging", "warnings", "informations", "successes", "skwalexe", "logging-rs", "rust-logging", "logger"]
+keywords = ["rust",  "logging", "rust-logging", "logger"]
 categories = ["logging", "logger", "logs"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
…t 5 keywords